### PR TITLE
Instructions Changed

### DIFF
--- a/install.html
+++ b/install.html
@@ -83,9 +83,8 @@
     </header>
     <section>
       <h2 style="margin-top: 0.83em;">Install FastForward</h2>
-      <p style="font-size: 20px;font-weight: bold;">Sorry, but your browser is not compatible with FastForward.</p>
       <p>FastForward is currently available for Chromium (Chrome, Opera, Kiwi), Firefox, and Microsoft Edge</p>
-      <a class="btn" href="https://www.mozilla.org/en-US/firefox/">Get Firefox</a>
+      <a class="btn" href="./instructions.html">Get Fastforward</a>
     </section>
 		<footer class="module top">
       <div class="footer-links">

--- a/js/instructions.js
+++ b/js/instructions.js
@@ -24,18 +24,18 @@ function nextPage(currentPage) {
 function loadEndPageContent() {
   var browser = browserSelect.options[browserSelect.selectedIndex].innerText;
   instructions = {
-    "Chrome" : `<p>Unfortunatly, FastForward was removed from the Chrome Web Store. You will have to manually install it instead.</p>
+    "Chrome" : `<p>Unfortunately, FastForward was removed from the Chrome Web Store. You will have to manually install it instead.</p>
     Manually Installing FastForward:<br>
     1. Download the zip file from <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_chromium.zip">this link</a>.<br>
     2. Unzip (extract) the zip file.<br>
-       This should leave you with a single file named <code>FastForward_chromium_0.XXXX.zip</code>.<br>
+    This should leave you with a single file named <code>FastForward_chromium_0.XXXX.zip</code>.<br>
     If the file is called <code>FastForward_chromium.zip</code>, you have not properly extracted it and will need to try again.<br>
     3. Open <code>${browser == "Opera" ? "opera" : browser == "Brave" ? "brave" : "chrome"}://extensions</code><br>
     4. Enable developer mode, which can be found in the top right corner.<br>
     5. Drag the <code>FastForward_chromium_0.XXXX</code> folder that you extracted into the extentions page.<br>
     FastForward should now be installed!`,
 
-    "Firefox" : `<p>Unfortunatly, FastForward was removed from the Firefox Store. You will have to manually install it instead.</p>
+    "Firefox" : `<p>Unfortunately, FastForward was removed from the Firefox Store. You will have to manually install it instead.</p>
     Manually Installing FastForward:<br>
     1. Download the zip file from <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_firefox.zip">this link</a>.<br>
     2. Unzip (extract) the zip file so that you have <code>FastForward_firefox_0.XXXX.xpi</code>.<br>

--- a/js/instructions.js
+++ b/js/instructions.js
@@ -24,27 +24,21 @@ function nextPage(currentPage) {
 function loadEndPageContent() {
   var browser = browserSelect.options[browserSelect.selectedIndex].innerText;
   instructions = {
-    "Chrome" : `<p>Unfortunatly, FastForward was removed from the Chrome Web Store. You will have to manually install it instead.</p>
-    Manually Installing FastForward:<br>
-    1. Download the zip file from our <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_chromium.zip">GitHub page</a>.<br>
-    2. Unzip the file.<br>
-    This should leave you with a single file named <code>FastForward_chromium_0.XXXX.zip</code>.<br>
-    If the file is called <code>FastForward_chromium.zip</code>, you have not properly extracted it and will need to try again.<br>
-    3. Open <code>${browser == "Opera" ? "opera" : browser == "Brave" ? "brave" : "chrome"}://extensions</code><br>
-    4. Enable developer mode, which can be found in the top right corner.<br>
-    5. Drag the <code>FastForward_chromium_0.XXXX</code> folder that you extracted into the extentions page.<br>
-    FastForward should now be installed!`,
-    "Firefox" : `<p>FastForward is avalible on the Mozilla Firefox Addons Store!</p>
-    <a href="https://addons.mozilla.org/en-US/firefox/addon/FastForwardteam/">Install FastForward</a>`,
-    "Edge" : `<p>FastForward is avalible on the Microsoft Edge Addons Store!</p>
+    "Chrome" : `<p>Unfortunately, FastForward was removed from the Chrome Web Store. You will have to manually install it instead.</p>
+    Please follow the installation instructions on our <a href="https://github.com/FastForwardTeam/FastForward/blob/main/INSTALLING.md#chromium-based-browsers-chrome-kiwi-opera-opera-gx-vivaldi-brave-etc">GitHub page</a>`,
+    "Firefox" : `<p>Unfortunately, FastForward was removed from the Firefox Store. You will have to manually install it instead.</p>
+    Please follow the installation instructions on our <a href="https://github.com/FastForwardTeam/FastForward/blob/main/INSTALLING.md#firefox-based-browsers-firefox-waterfox-pale-moon-librewolf-etc">GitHub page</a>`,
+    "Edge" : `<p>FastForward is available on the Microsoft Edge Addons Store!</p>
     <a href="https://microsoftedge.microsoft.com/addons/detail/FastForward/ldcclmkclhomnpcnccgbgleikchbnecl/">Install FastForward</a>`,
-    "Safari" : `<p>Unfortunatly, FastForward is not currently supported on Safari.</p>
-    We reccomend that you download Mozilla Firefox or Google Chrome instead.<br>
+    "Safari" : `<p>Unfortunately, FastForward is not currently supported on Safari.</p>
+    We recommend that you download Mozilla Firefox or Google Chrome instead.<br>
     <a href="https://www.mozilla.org/en-US/firefox/new/">Download Firefox</a><br>
     <a href="https://www.google.com/chrome/">Download Chrome</a>`,
-    "Other": `<p>You can download FastForward builds with the folling links:</p>
+    "Other": `<p>You can download FastForward builds with the following links:</p>
     <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_chromium.zip">Download FastForward for Chromium Based Browsers</a><br>
     <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_firefox.zip">Download FastForward for Firefox Based Browsers</a><br>
+    <br>
+    <a href="https://github.com/FastForwardTeam/FastForward/blob/main/INSTALLING.md">Installation Instructions</a><br>
     <p>If your browser isn't one of these, please contact us on our <a href="https://discord.com/invite/RSAf7b5njt">Discord server</a></p>`
   }
 

--- a/js/instructions.js
+++ b/js/instructions.js
@@ -24,16 +24,36 @@ function nextPage(currentPage) {
 function loadEndPageContent() {
   var browser = browserSelect.options[browserSelect.selectedIndex].innerText;
   instructions = {
-    "Chrome" : `<p>Unfortunately, FastForward was removed from the Chrome Web Store. You will have to manually install it instead.</p>
-    Please follow the installation instructions on our <a href="https://github.com/FastForwardTeam/FastForward/blob/main/INSTALLING.md#chromium-based-browsers-chrome-kiwi-opera-opera-gx-vivaldi-brave-etc">GitHub page</a>`,
-    "Firefox" : `<p>Unfortunately, FastForward was removed from the Firefox Store. You will have to manually install it instead.</p>
-    Please follow the installation instructions on our <a href="https://github.com/FastForwardTeam/FastForward/blob/main/INSTALLING.md#firefox-based-browsers-firefox-waterfox-pale-moon-librewolf-etc">GitHub page</a>`,
-    "Edge" : `<p>FastForward is available on the Microsoft Edge Addons Store!</p>
+    "Chrome" : `<p>Unfortunatly, FastForward was removed from the Chrome Web Store. You will have to manually install it instead.</p>
+    Manually Installing FastForward:<br>
+    1. Download the zip file from <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_chromium.zip">this link</a>.<br>
+    2. Unzip (extract) the zip file.<br>
+       This should leave you with a single file named <code>FastForward_chromium_0.XXXX.zip</code>.<br>
+    If the file is called <code>FastForward_chromium.zip</code>, you have not properly extracted it and will need to try again.<br>
+    3. Open <code>${browser == "Opera" ? "opera" : browser == "Brave" ? "brave" : "chrome"}://extensions</code><br>
+    4. Enable developer mode, which can be found in the top right corner.<br>
+    5. Drag the <code>FastForward_chromium_0.XXXX</code> folder that you extracted into the extentions page.<br>
+    FastForward should now be installed!`,
+
+    "Firefox" : `<p>Unfortunatly, FastForward was removed from the Firefox Store. You will have to manually install it instead.</p>
+    Manually Installing FastForward:<br>
+    1. Download the zip file from <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_firefox.zip">this link</a>.<br>
+    2. Unzip (extract) the zip file so that you have <code>FastForward_firefox_0.XXXX.xpi</code>.<br>
+    3. Open <code>about:config</code>, and press Accept the Risk and Continue.<br>
+    4. Search for <code>xpinstall.signatures.required</code>, and make sure it is set to false using the button on the right.<br>
+    5. Restart Firefox by closing all browser windows and opening it again.
+    6. Open <code>about:addons</code><br>
+    7. Drag your <code>FastForward_firefox_X.XXXX.xpi</code> into Firefox, and click "add" when prompted.<br>
+    FastForward should now be installed!`,
+
+    "Edge" : `<p>FastForward is avalible on the Microsoft Edge Addons Store!</p>
     <a href="https://microsoftedge.microsoft.com/addons/detail/FastForward/ldcclmkclhomnpcnccgbgleikchbnecl/">Install FastForward</a>`,
+
     "Safari" : `<p>Unfortunately, FastForward is not currently supported on Safari.</p>
     We recommend that you download Mozilla Firefox or Google Chrome instead.<br>
     <a href="https://www.mozilla.org/en-US/firefox/new/">Download Firefox</a><br>
     <a href="https://www.google.com/chrome/">Download Chrome</a>`,
+
     "Other": `<p>You can download FastForward builds with the following links:</p>
     <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_chromium.zip">Download FastForward for Chromium Based Browsers</a><br>
     <a href="https://nightly.link/FastForwardTeam/FastForward/workflows/main/main/FastForward_firefox.zip">Download FastForward for Firefox Based Browsers</a><br>


### PR DESCRIPTION
Updated Firefox instructions until we get back on the mozzarella store,
Included link to manual installation instructions in "other" browser option,
Changed chrome installations instructions to be a link to the github repo so we only have to maintain one set of instructions,
Changed install.html to point to the instructions

