### PR TITLE
Fix google indexing issues

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+# Robots.txt for FastForward.team
+# allow all
+User-agent: * 
+Allow: /
+
+# Sitemap
+Sitemap: https://fastforward.team/sitemap.xml


### PR DESCRIPTION
Google said that the current site blocks the changelog from being read by its robots.txt file (that doesn't exist??? idk what google is talking about) so here's one in order to try fix it. not that we really want or need the changelog to be indexed anyway since it just redirects, but its probably good practice.